### PR TITLE
Add version information into UI

### DIFF
--- a/pkg/dashboard/static/index.html
+++ b/pkg/dashboard/static/index.html
@@ -44,6 +44,9 @@
                 </div>
             </div>
 
+            <div id="toolVersion">
+            </div>
+            
             <div class="separator-vertical mx-3"><span></span></div>
 
             <ul class="navbar-nav me-auto mb-2 mb-lg-0">

--- a/pkg/dashboard/static/scripts.js
+++ b/pkg/dashboard/static/scripts.js
@@ -21,6 +21,12 @@ $(function () {
             $("#upgradeModal .btn-scan").hide()
         }
     })
+
+    $.get("/status").fail(function (xhr) {
+        reportError("Failed to get tool version", xhr)
+    }).done(function (data) {
+        fillToolVersion(data)
+    })
 })
 
 function initView() {
@@ -195,4 +201,8 @@ function isNewerVersion(oldVer, newVer) {
         if (a < b) return false
     }
     return false
+}
+
+function fillToolVersion(data) {
+    $("#toolVersion").append($('<a>' + data + '</a>'))
 }


### PR DESCRIPTION
This commit adds the tool version to the UI in the top bar.
fix #33 
Visual Examples:
![WhatsApp Image 2022-10-24 at 23 42 09](https://user-images.githubusercontent.com/40122521/197628570-1916391f-0c97-499e-bc51-bee4cd4b1db1.jpeg)
![WhatsApp Image 2022-10-24 at 23 41 05](https://user-images.githubusercontent.com/40122521/197628609-92ad8bcf-7178-48e5-9c74-455d142d2b62.jpeg)


