### PR TITLE
refactoring makefile, also adding phony test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,24 @@
-pull:
-	git pull
+DATE    ?= $(shell date +%FT%T%z)
+VERSION ?= $(git describe --tags --always --dirty --match=v* 2> /dev/null || \
+			cat $(CURDIR)/.version 2> /dev/null || echo "v0")
 
-build:
-	go build -o bin/dashboard .
+.PHONY: test
+test: ; $(info $(M) start unit testing...) @
+	@go test $$(go list ./... | grep -v /mocks/) --race -v -short -coverprofile=profile.cov
+	@echo "\n*****************************"
+	@echo "**  TOTAL COVERAGE: $$(go tool cover -func profile.cov | grep total | grep -Eo '[0-9]+\.[0-9]+')%  **"
+	@echo "*****************************\n"
 
+.PHONY: pull
+pull: ; $(info $(M) Pulling source...) @
+	@git pull
 
-debug:
-	 DEBUG=1 ./bin/dashboard
+.PHONY: build
+build: $(BIN) ; $(info $(M) Building executable...) @ ## Build program binary
+	$Q $(GO) build \
+		-ldflags '-X main.version=$(VERSION) -X main.buildDate=$(DATE)' \
+		-o bin/dashboard .
+
+.PHONY: debug
+debug: ; $(info $(M) Running dashboard in debug mode...) @
+	@DEBUG=1 ./bin/dashboard


### PR DESCRIPTION
Hi @undera, continuing contribution for refactoring makefile, I am adding some changes : 

- extra flag version and buildDate in build make command.
- adding unit test in make command

here is the result of executing make command

1. make test
`
$make test
 start unit testing...
go: downloading k8s.io/apimachinery v0.25.0-alpha.2
go: downloading github.com/sirupsen/logrus v1.9.0
go: downloading github.com/hashicorp/go-version v1.6.0
go: downloading github.com/gin-gonic/gin v1.8.1
go: downloading github.com/hexops/gotextdiff v1.0.3
go: downloading helm.sh/helm/v3 v3.9.4
go: downloading github.com/jessevdk/go-flags v1.5.0
go: downloading github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
go: downloading golang.org/x/sys v0.0.0-20220818161305-2296e01440c6
go: downloading github.com/gin-contrib/sse v0.1.0
go: downloading github.com/mattn/go-isatty v0.0.16
go: downloading golang.org/x/net v0.0.0-20220906165146-f3363e06e74c
go: downloading github.com/go-playground/validator/v10 v10.11.0
go: downloading github.com/pelletier/go-toml/v2 v2.0.3
go: downloading github.com/ugorji/go/codec v1.2.7
go: downloading google.golang.org/protobuf v1.28.1
go: downloading gopkg.in/yaml.v2 v2.4.0
go: downloading github.com/google/gofuzz v1.2.0
go: downloading k8s.io/klog/v2 v2.70.0
go: downloading sigs.k8s.io/structured-merge-diff/v4 v4.2.1
go: downloading golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8
go: downloading k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9
go: downloading gopkg.in/inf.v0 v0.9.1
go: downloading sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2
go: downloading github.com/Masterminds/semver/v3 v3.1.1
go: downloading github.com/go-logr/logr v1.2.3
go: downloading github.com/json-iterator/go v1.1.12
go: downloading github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
go: downloading github.com/modern-go/reflect2 v1.0.2
?       github.com/komodorio/helm-dashboard     [no test files]
?       github.com/komodorio/helm-dashboard/pkg/dashboard       [no test files]
?       github.com/komodorio/helm-dashboard/pkg/dashboard/handlers      [no test files]
?       github.com/komodorio/helm-dashboard/pkg/dashboard/scanners      [no test files]
=== RUN   TestFlow
time="2022-11-03T22:49:14+07:00" level=debug msg="Starting command: [kubectl config get-contexts]"
time="2022-11-03T22:49:15+07:00" level=debug msg="Command STDOUT:\nCURRENT   NAME   CLUSTER   AUTHINFO   NAMESPACE\n"
time="2022-11-03T22:49:15+07:00" level=debug msg="Command STDERR:\n"
    data_test.go:20: 
--- SKIP: TestFlow (0.11s)
PASS
coverage: 10.3% of statements
ok      github.com/komodorio/helm-dashboard/pkg/dashboard/subproc       0.743s  coverage: 10.3% of statements
=== RUN   TestGetQueryProps
=== RUN   TestGetQueryProps/Get_query_props_-_all_set_with_revRequired_true
=== RUN   TestGetQueryProps/Get_query_props_-_no_revision_with_revRequired_true
=== RUN   TestGetQueryProps/Get_query_props_-_no_namespace_with_revRequired_true
=== RUN   TestGetQueryProps/Get_query_props_-_no_name_with_revRequired_true
--- PASS: TestGetQueryProps (0.00s)
    --- PASS: TestGetQueryProps/Get_query_props_-_all_set_with_revRequired_true (0.00s)
    --- PASS: TestGetQueryProps/Get_query_props_-_no_revision_with_revRequired_true (0.00s)
    --- PASS: TestGetQueryProps/Get_query_props_-_no_namespace_with_revRequired_true (0.00s)
    --- PASS: TestGetQueryProps/Get_query_props_-_no_name_with_revRequired_true (0.00s)
=== RUN   TestChartAndVersion
=== RUN   TestChartAndVersion/Chart_and_version_-_successfully_parsing_chart_and_version
=== RUN   TestChartAndVersion/Chart_and_version_-_parsing_chart_without_version
--- PASS: TestChartAndVersion (0.00s)
    --- PASS: TestChartAndVersion/Chart_and_version_-_successfully_parsing_chart_and_version (0.00s)
    --- PASS: TestChartAndVersion/Chart_and_version_-_parsing_chart_without_version (0.00s)
PASS
coverage: 31.1% of statements
ok      github.com/komodorio/helm-dashboard/pkg/dashboard/utils 0.401s  coverage: 31.1% of statements

*****************************
**  TOTAL COVERAGE: 13.7%  **
*****************************
`
2. make pull
`
$make pull                                                 
 Pulling source...
`

Thank you 

