### PR TITLE
CLI Flag --bind

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ You can see the list of available command-line flags by running `helm dashboard 
 
 By default, the web server is only available locally. You can change that by specifying `HD_BIND` environment variable
 to the desired value. For example, `0.0.0.0` would bind to all IPv4 addresses or `[::0]` would be all IPv6 addresses.
+This can also be specified using flag `--bind <host>`, for example `--bind=0.0.0.0` or `--bind 0.0.0.0`.
+> Precedence order: flag `--bind=<host>` > env `HD_BIND=<host>` > default value `localhost`
 
 If your port 8080 is busy, you can specify a different port to use via `--port <number>` command-line flag.
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/jessevdk/go-flags v1.5.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8
 	github.com/sirupsen/logrus v1.9.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -31,7 +32,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.3 // indirect
 	github.com/ugorji/go/codec v1.2.7 // indirect
 	golang.org/x/crypto v0.0.0-20220817201139-bc19a97f63c8 // indirect


### PR DESCRIPTION
# Motivation
[Issue 75](https://github.com/komodorio/helm-dashboard/issues/75)

# Changes
1. Adds `--bind` flag field in `options` in `main` package.
2. Function `StartServer` (and few other internal functions) made method(s) to a newly introduced type `Server`.

# Summary
- Introduction of new flag `--bind` for binding-host-address to be read from CLI flag also (earlier: env and default only). The precedence order now is:
flag `--bind=<host>` > env `HD_BIND=<host>` > default value `localhost`
- `StartServer` and other internal functions are made methods to type `Server` in order to limit the number of arguments passed. This way, the code is cleaner.

# Related Issues
Closes https://github.com/komodorio/helm-dashboard/issues/75

# Message for Maintainers
Given the current setup of function calls in most packages (observed specifically on `main`, `pkg/dashboard` and `pkg/dashboard/subproc` packages with this change), the mocking for unit tests is hardly possible. Hence, the current change was tested manually. Also, the code coverage is low.

Please confirm if issues and PRs will be accepted to revamp code to certain level. Roughly put, this would require the following things:
1. Introduce types in every package and make methods of most functions, if not all.
2. Functionally break/organize methods for testability.
3. Introduce more interfaces for mocking.