### PR TITLE
New CLI Flag `--devel` To Include Development/Prerelease Versions of Charts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/komodorio/helm-dashboard
 go 1.18
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/eko/gocache/v3 v3.1.2
 	github.com/gin-gonic/gin v1.8.1
 	github.com/hashicorp/go-version v1.6.0
@@ -17,12 +18,14 @@ require (
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 	gopkg.in/yaml.v3 v3.0.1
+	gotest.tools/v3 v3.4.0
 	helm.sh/helm/v3 v3.11.1
 	k8s.io/api v0.26.0
 	k8s.io/apimachinery v0.26.0
 	k8s.io/cli-runtime v0.26.0
 	k8s.io/client-go v0.26.0
 	k8s.io/kubectl v0.26.0
+	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 )
 
 require (
@@ -30,7 +33,6 @@ require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.3 // indirect
 	github.com/XiaoMi/pegasus-go-client v0.0.0-20210427083443-f3b6b08bc4c2 // indirect
@@ -149,13 +151,11 @@ require (
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gotest.tools/v3 v3.4.0
 	k8s.io/apiextensions-apiserver v0.26.0 // indirect
 	k8s.io/apiserver v0.26.0 // indirect
 	k8s.io/component-base v0.26.0 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
-	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d
 	oras.land/oras-go v1.2.2 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/kustomize/api v0.12.1 // indirect

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type options struct {
 	BindHost   string `long:"bind" description:"Host binding to start server (default: localhost)"` // default should be printed but not assigned as the precedence: flag > env > default
 	Port       uint   `short:"p" long:"port" description:"Port to start server on" default:"8080"`
 	Namespace  string `short:"n" long:"namespace" description:"Namespace for HELM operations"`
+	Devel      bool   `long:"devel" description:"Include development versions of charts"`
 }
 
 func main() {
@@ -50,6 +51,7 @@ func main() {
 		Address:    fmt.Sprintf("%s:%d", opts.BindHost, opts.Port),
 		Debug:      opts.Verbose,
 		NoTracking: opts.NoTracking,
+		Devel:      opts.Devel,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/dashboard/api_test.go
+++ b/pkg/dashboard/api_test.go
@@ -1,6 +1,15 @@
 package dashboard
 
 import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/gin-gonic/gin"
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/handlers"
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/objects"
@@ -13,14 +22,6 @@ import (
 	"helm.sh/helm/v3/pkg/registry"
 	"helm.sh/helm/v3/pkg/storage"
 	"helm.sh/helm/v3/pkg/storage/driver"
-	"io/ioutil"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"os"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 var inMemStorage *storage.Storage
@@ -111,7 +112,7 @@ func TestConfigureRoutes(t *testing.T) {
 
 	// Required arguements for route configuration
 	abortWeb := func() {}
-	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig)
+	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -131,7 +132,7 @@ func TestContextSetter(t *testing.T) {
 	con := GetTestGinContext(w)
 
 	// Required arguements
-	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig)
+	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -161,7 +162,7 @@ func TestNewRouter(t *testing.T) {
 
 	// Required arguemnets
 	abortWeb := func() {}
-	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig)
+	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -183,7 +184,7 @@ func TestConfigureScanners(t *testing.T) {
 	}
 
 	// Required arguemnets
-	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig)
+	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -206,7 +207,7 @@ func TestConfigureKubectls(t *testing.T) {
 	}
 
 	// Required arguemnets
-	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig)
+	data, err := objects.NewDataLayer([]string{"TestSpace"}, "T-1", NewHelmConfig, false)
 
 	if err != nil {
 		t.Fatal(err)
@@ -226,7 +227,7 @@ func TestConfigureKubectls(t *testing.T) {
 
 func TestE2E(t *testing.T) {
 	// Initialize data layer
-	data, err := objects.NewDataLayer([]string{""}, "0.0.0-test", getFakeHelmConfig)
+	data, err := objects.NewDataLayer([]string{""}, "0.0.0-test", getFakeHelmConfig, false)
 	assert.NilError(t, err)
 
 	// Create a new router with the function

--- a/pkg/dashboard/objects/data_test.go
+++ b/pkg/dashboard/objects/data_test.go
@@ -15,6 +15,7 @@ func TestNewDataLayer(t *testing.T) {
 		namespaces    []string
 		version       string
 		helmConfig    HelmConfigGetter
+		devel         bool
 		errorExpected bool
 	}{
 		{
@@ -22,6 +23,7 @@ func TestNewDataLayer(t *testing.T) {
 			namespaces:    []string{"namespace1", "namespace2"},
 			version:       "1.0.0",
 			helmConfig:    nil,
+			devel:         false,
 			errorExpected: true,
 		},
 		{
@@ -34,12 +36,13 @@ func TestNewDataLayer(t *testing.T) {
 			helmConfig: func(sett *cli.EnvSettings, ns string) (*action.Configuration, error) {
 				return &action.Configuration{}, nil
 			},
+			devel:         false,
 			errorExpected: false,
 		},
 	}
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			dl, err := NewDataLayer(tt.namespaces, tt.version, tt.helmConfig)
+			dl, err := NewDataLayer(tt.namespaces, tt.version, tt.helmConfig, tt.devel)
 			if tt.errorExpected {
 				assert.Error(t, err, "Expected error but got nil")
 			} else {

--- a/pkg/dashboard/objects/testdata/repositories-invalid-cache-file.yaml
+++ b/pkg/dashboard/objects/testdata/repositories-invalid-cache-file.yaml
@@ -1,0 +1,6 @@
+apiVersion: ""
+generated: "0001-01-01T00:00:00Z"
+repositories:
+- cache: non-existing-index.yaml
+  name: non-existing
+  url: http://example.com/charts

--- a/pkg/dashboard/objects/testdata/repositories-malformed-manifest.yaml
+++ b/pkg/dashboard/objects/testdata/repositories-malformed-manifest.yaml
@@ -1,0 +1,12 @@
+apiVersion: ""
+generated: "0001-01-01T00:00:00Z"
+- repositories:
+- caFile: ""
+  certFile: ""
+  insecure_skip_tls_verify: false
+  keyFile: ""
+  name: charts
+  pass_credentials_all: false
+  password: ""
+  url: https://charts.helm.sh/stable
+  username: ""

--- a/pkg/dashboard/objects/testdata/testing-index.yaml
+++ b/pkg/dashboard/objects/testdata/testing-index.yaml
@@ -64,3 +64,37 @@ entries:
           email: containers@bitnami.com
       icon: ""
       apiVersion: v2
+  traefik:
+    - apiVersion: v1
+      appVersion: 1.7.26
+      deprecated: true
+      description: A Traefik based Kubernetes ingress controller with Let's
+        Encrypt support
+      home: https://traefik.io/
+      icon: https://docs.traefik.io/assets/img/traefik.logo.png
+      keywords:
+      - traefik
+      - ingress
+      - acme
+      - letsencrypt
+      name: traefik
+      sources:
+      - https://github.com/containous/traefik
+      - https://github.com/helm/charts/tree/master/stable/traefik
+      version: 1.87.7-rc1
+  rabbitmq:
+    - apiVersion: v1
+      appVersion: 3.8.2
+      deprecated: true
+      description: DEPRECATED Open source message broker software that implements the Advanced
+        Message Queuing Protocol (AMQP)
+      home: https://www.rabbitmq.com
+      icon: https://bitnami.com/assets/stacks/rabbitmq/img/rabbitmq-stack-220x234.png
+      keywords:
+      - rabbitmq
+      - message queue
+      - AMQP
+      name: rabbitmq
+      sources:
+      - https://github.com/bitnami/bitnami-docker-rabbitmq
+      version: invalid-version

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/joomcode/errorx"
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/objects"
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/subproc"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/registry"
-	"net/http"
-	"os"
-	"strings"
-	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/hashicorp/go-version"
@@ -28,10 +29,11 @@ type Server struct {
 	Address    string
 	Debug      bool
 	NoTracking bool
+	Devel      bool
 }
 
 func (s *Server) StartServer(ctx context.Context, cancel context.CancelFunc) (string, utils.ControlChan, error) {
-	data, err := objects.NewDataLayer(s.Namespaces, s.Version, NewHelmConfig)
+	data, err := objects.NewDataLayer(s.Namespaces, s.Version, NewHelmConfig, s.Devel)
 	if err != nil {
 		return "", nil, errorx.Decorate(err, "Failed to create data layer")
 	}


### PR DESCRIPTION
# Motivation
[Issue][1] #94 

# Changes
1. New CLI flag `--devel`.
2. Tests to cover `Charts()`  and `Containing()`.

# Summary
CLI flag `--devel` to list/include development (prerelease versions like release candidate, alpha, beta, etc.) in the following endpoints:
- /api/helm/repositories/\<repo>
- /api/helm/repositories/versions?name=\<repo>
- /api/helm/repositories/latestver?name=\<repo>

# Related Issues
Closes #94 

[1]: https://github.com/komodorio/helm-dashboard/issues/94