### PR TITLE
🎨 Remove Superfluous Rule from helm-dashboard ClusterRole

### DIFF
--- a/charts/helm-dashboard/templates/serviceaccount.yaml
+++ b/charts/helm-dashboard/templates/serviceaccount.yaml
@@ -19,11 +19,10 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
-    verbs: ["get", "list", "watch"]
   {{- if .Values.dashboard.allowWriteActions }}
-  - apiGroups: ["*"]
-    resources: ["*"]
     verbs: ["get", "list", "watch", "create", "delete", "patch", "update"]
+  {{- else }}
+    verbs: ["get", "list", "watch"]
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
A superfluous rule is added to the ClusterRole upon creation, when the dashboard.allowWriteActions value is set to true. This commit will ensure that only a single rule is created within the ClusterRole, regardless of whether the dashboard.allowWriteActions value is enabled or not.
The verbs within this rule will update accordingly.

<!-- If your PR fixes an open issue, use `Closes #999` to link your PR with the issue. #999 stands for the issue number you are fixing -->

## Fixes Issue

Closes #186.

## Changes proposed

- Creates a single rule withing the ClusterRole, rather than two.
- Verb list for proposed single rule will be updated, according to value of `dashboard.allowWriteActions`
- When `dashboard.allowWriteActions` is `true`, write-oriented verbs will be include
- When `dashboard.allowWriteActions` is `false`, write-oriented verbs will be excluded

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] The title of my pull request is a short description of the requested changes.

## Note to reviewers

I have tested this locally and confirmed the ClusterRole updates accordingly.
