### PR TITLE
✅ Add test for subproc/data.go GetStatus Function

### DIFF
--- a/pkg/dashboard/subproc/data_test.go
+++ b/pkg/dashboard/subproc/data_test.go
@@ -1,12 +1,13 @@
 package subproc
 
 import (
+	"sync"
+	"testing"
+
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/utils"
 	log "github.com/sirupsen/logrus"
 	"helm.sh/helm/v3/pkg/release"
 	v1 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
-	"sync"
-	"testing"
 )
 
 func TestFlow(t *testing.T) {
@@ -14,7 +15,8 @@ func TestFlow(t *testing.T) {
 
 	var _ release.Status
 	data := DataLayer{
-		Cache: NewCache(),
+		Cache:      NewCache(),
+		StatusInfo: &StatusInfo{},
 	}
 	err := data.CheckConnectivity()
 	if err != nil {
@@ -87,4 +89,8 @@ func TestFlow(t *testing.T) {
 		t.Fatal(err)
 	}
 	_ = diff
+
+	status := data.GetStatus()
+	_ = status
+
 }


### PR DESCRIPTION
## Fixes issue

Contributes towards #148 - Add Unit Tests

Adds a test for subproc/data.go GetStatus function.

## Changes proposed
- Add a simple function call

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X ] The title of my pull request is a short description of the requested changes.

## Screenshots

<!-- Add all the screenshots which support your changes -->

## Note to reviewers

Although I wouldn't necessarily classify the existing tests in `data.go` as traditional unit tests, I will run with the current testing structure to increase the test coverage in the first instance. Might be worth adding more test structs in the future for example. Not a go or unit testing expert, just what I have read on best practice.

Thanks for reviewing!

