### PR TITLE
🔧 Allow binary arguments via helm chart

### DIFF
--- a/charts/helm-dashboard/README.md
+++ b/charts/helm-dashboard/README.md
@@ -73,6 +73,7 @@ The following table lists the configurable parameters of the chart and their def
 | `dashboard.persistence.size`         | Persistent Volume size                                                                         | `100M`                               |
 | `dashboard.persistence.hostPath`     | Set path in case you want to use local host path volumes (not recommended in production)       | `""`
 | `updateStrategy.type`                | Set up update strategy for helm-dashboard installation.                                        | `RollingUpdate`                    |             
+| `extraArgs`     | Set the arguments to be supplied to the helm-dashboard binary       | `[--no-browser, --bind=0.0.0.0]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/charts/helm-dashboard/templates/deployment.yaml
+++ b/charts/helm-dashboard/templates/deployment.yaml
@@ -30,6 +30,12 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
+          command:
+            - /bin/helm-dashboard
+          args:
+          {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -111,6 +111,10 @@ autoscaling:
 
 nodeSelector: {}
 
+extraArgs:
+  - --no-browser
+  - --bind=0.0.0.0
+
 tolerations: []
 
 affinity: {}


### PR DESCRIPTION
This commit allows to pass arguments to the helm chart. This is useful if you want to specify arguments for the helm-dashboard binary whilst deploying via helm.

## Fixes Issue

Closes #200 .

## Changes proposed

Arguments to the `helm-dashboard` binary can be supplied by utilising the `extraArgs` parameter within the supplied helm values.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [X] My code follows the code style of this project.
- [X] My change requires changes to the documentation.
- [X] I have updated the documentation accordingly.
- [X] All new and existing tests passed.
- [X] The title of my pull request is a short description of the requested changes.
