### PR TITLE
fix: Make PVC use storageClass from values

### DIFF
--- a/charts/helm-dashboard/templates/pvc.yaml
+++ b/charts/helm-dashboard/templates/pvc.yaml
@@ -13,6 +13,8 @@ metadata:
 spec:
   {{- if .Values.dashboard.persistence.hostPath }}
   storageClassName: ""
+  {{- else }}
+  storageClassName: "{{ .Values.dashboard.persistence.storageClass }}"
   {{- end }}
   accessModes:
   {{- if not (empty .Values.dashboard.persistence.accessModes) }}


### PR DESCRIPTION
## Changes proposed

Fix the missing use of storageClass in the helm chart.

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [ ] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] The title of my pull request is a short description of the requested changes.

## Note to reviewers

I've already mistakingly opened this as https://github.com/komodorio/helm-charts/pull/145
