### PR TITLE
Removing redundant table header

### DIFF
--- a/pkg/dashboard/static/index.html
+++ b/pkg/dashboard/static/index.html
@@ -162,14 +162,6 @@
                                placeholder="Filter..."/>
                     </div>
                 </div>
-                <div class="bg-secondary rounded-bottom m-0 row p-2">
-                    <div class="col-4 hdr-name">Name</div>
-                    <div class="col-3">Release Status</div>
-                    <div class="col-2">Chart</div>
-                    <div class="col-1">Revision</div>
-                    <div class="col-1">Namespace</div>
-                    <div class="col-1">Updated</div>
-                </div>
             </div>
 
             <div class="body"></div>


### PR DESCRIPTION
## Changes Proposed

- Removing redundant table header from Installed charts page

## Check List

- [X] The title of my pull request is a short description of the changes
- [ ] This PR relates to some issue: <!-- use "Closes #999" to auto-close related issue -->
- [ ] I have documented the changes made (if applicable)
- [ ] I have covered the changes with unit tests

