### PR TITLE
Fix storybook script - did not worked before the change.

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -38,7 +38,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
+    "storybook": "set NODE_OPTIONS=--openssl-legacy-provider && start-storybook -p 6006",
     "build-storybook": "build-storybook",
     "lint": "npx eslint src/",
     "lint:fix": "npm run lint -- --fix",


### PR DESCRIPTION
## Changes Proposed

Fix the storybook script from :
"storybook": "NODE_OPTIONS=--openssl-legacy-provider start-storybook -p 6006",
to
"storybook": " **set** NODE_OPTIONS=--openssl-legacy-provider **&&** start-storybook -p 6006",

so now the storybook runs, before it did not.
