### PR TITLE
Adding multi-arch build support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
         run: "dist/helm-dashboard_linux_amd64_v1/helm-dashboard --help"
 
   image:
-    runs-on: ubuntu-latest
+    runs-on: actuated
     needs: [release, pre_release]
     timeout-minutes: 60
     steps:
@@ -68,7 +68,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         if: github.event_name != 'pull_request'
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
@@ -83,7 +83,7 @@ jobs:
           tags: komodorio/helm-dashboard:${{ needs.pre_release.outputs.release_tag }},komodorio/helm-dashboard:latest
           labels: ${{ steps.meta.outputs.labels }}
           build-args: VER=${{ needs.pre_release.outputs.release_tag }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/arm64/v8,linux/arm/v6,linux/arm/v7
 
   publish_chart:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.dll
 *.so
 *.dylib
+*.image
 
 # Test binary, built with `go test -c`
 *.test

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ADD . src
 
 WORKDIR /build/src
 
-RUN make build
+RUN env && make build
 
 # Stage - runner
 FROM --platform=${BUILDPLATFORM:-linux/amd64} alpine
@@ -51,4 +51,4 @@ ENTRYPOINT ["/bin/helm-dashboard", "--no-browser", "--bind=0.0.0.0", "--port=808
 ## Install QEMU
 # docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 ## Run a build for the different platforms
-# docker buildx build -t komodorio/helm-dashboard:0.0.0 --platform=linux/arm64,linux/amd64 --output type=local,dest=hdb.image . && kind load docker-image komodorio/helm-dashboard:0.0.0
+# docker buildx build -t komodorio/helm-dashboard:0.0.0 --platform=linux/arm64,linux/amd64 --output type=local,dest=hdb.image --progress=plain . && kind load docker-image komodorio/helm-dashboard:0.0.0


### PR DESCRIPTION
## Changes Proposed

Closes komodorio/helm-dashboard#365
<!-- Describe the proposed changes and any additional information -->
This is an approach to build multiarch docker images:
* linux/amd64
* linux/arm64
* linux/arm64/v8
* linux/arm/v6
* linux/arm/v7
