### PR TITLE
Migrated Storybook notation from CSF2 to CSF3

### DIFF
--- a/frontend/src/components/Badge.stories.tsx
+++ b/frontend/src/components/Badge.stories.tsx
@@ -14,29 +14,24 @@
  * @see https://storybook.js.org/docs/react/writing-stories/introduction
  */
 
-import { ComponentStory } from "@storybook/react";
-import Badge, { BadgeProps } from "./Badge";
+import { Meta } from "@storybook/react";
+import Badge from "./Badge";
 
-// We create a generic template for the component.
-
-const Template: ComponentStory<typeof Badge> = (args: BadgeProps) => (
-  <Badge {...args} />
-);
-// We export the story, and we pass the template to it. For now,
-// we are only going to use the default story.
-export const Default = Template.bind({});
-// We set the props for the story. Recall that the props are the same as the
-// ones in BadgeProps, which we impoted.
-Default.args = {
-  type: "success",
-  children: "Success",
-};
 // We set the metadata for the story.
 // Refer to https://storybook.js.org/docs/react/writing-stories/introduction
 // for more information.
-export default {
+const meta = {
   title: "Badge",
   component: Badge,
+  args: {
+    type: "success",
+    children: "Success",
+  },
+} satisfies Meta<typeof Badge>;
+
+export default meta;
+
+export const Default = {
   args: {
     type: "success",
     children: "Success",

--- a/frontend/src/components/Button.stories.tsx
+++ b/frontend/src/components/Button.stories.tsx
@@ -1,35 +1,28 @@
 /* eslint-disable no-console */
-// Status.stories.ts|tsx
+import { Meta } from "@storybook/react";
+import Button from "./Button";
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import Button, { ButtonProps } from "./Button";
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "Button",
   component: Button,
-} as ComponentMeta<typeof Button>;
+} satisfies Meta<typeof Button>;
 
-// Recall that Button has 'props' which is of type ButtonProps
-// We want to past theme to the story with the name 'Default', so we
-// create a template for it.
-// We want to declare default values for the props, so we create a
-// default args object.
-const Template: ComponentStory<typeof Button> = (args: ButtonProps) => (
-  <Button {...args} />
-);
-export const Default = Template.bind({});
-Default.args = {
-  children: (
-    <>
-      <span>&uarr;</span>
-      <span>Update</span>
-    </>
-  ),
-  onClick: () => {
-    console.log("click");
+export default meta;
+
+export const Default = {
+  args: {
+    children: (
+      <>
+        <span>&uarr;</span>
+        <span>Update</span>
+      </>
+    ),
+    onClick: () => {
+      console.log("click");
+    },
   },
 };

--- a/frontend/src/components/ClustersList.stories.tsx
+++ b/frontend/src/components/ClustersList.stories.tsx
@@ -1,21 +1,20 @@
 /* eslint-disable no-console */
-// ClustersListBar.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import ClustersList from "./ClustersList";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "ClustersList",
   component: ClustersList,
-} as ComponentMeta<typeof ClustersList>;
+} satisfies Meta<typeof ClustersList>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof ClustersList> = () => (
+const Template: StoryFn<typeof ClustersList> = () => (
   <ClustersList
     filteredNamespaces={[""]}
     installedReleases={[]}
@@ -26,4 +25,6 @@ const Template: ComponentStory<typeof ClustersList> = () => (
   />
 );
 
-export const Default = Template.bind({});
+export const Default = {
+  render: Template,
+};

--- a/frontend/src/components/InstalledPackages/InstalledPackageCard.stories.tsx
+++ b/frontend/src/components/InstalledPackages/InstalledPackageCard.stories.tsx
@@ -1,41 +1,35 @@
-// InstalledPackageCard.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import InstalledPackageCard from "./InstalledPackageCard";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "InstalledPackageCard",
   component: InstalledPackageCard,
-} as ComponentMeta<typeof InstalledPackageCard>;
+} satisfies Meta<typeof InstalledPackageCard>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof InstalledPackageCard> = (args) => (
-  <InstalledPackageCard {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  release: {
-    id: "",
-    name: "",
-    namespace: "",
-    revision: 1,
-    updated: "",
-    status: "",
-    chart: "",
-    chart_name: "",
-    chart_ver: "",
-    app_version: "",
-    icon: "",
-    description: "",
-    has_tests: false,
-    chartName: "", // duplicated in some cases in the backend, we need to resolve this
-    chartVersion: "", // duplicated in some cases in the backend, we need to resolve this
+export const Default = {
+  args: {
+    release: {
+      id: "",
+      name: "",
+      namespace: "",
+      revision: 1,
+      updated: "",
+      status: "",
+      chart: "",
+      chart_name: "",
+      chart_ver: "",
+      app_version: "",
+      icon: "",
+      description: "",
+      has_tests: false,
+      chartName: "", // duplicated in some cases in the backend, we need to resolve this
+      chartVersion: "", // duplicated in some cases in the backend, we need to resolve this
+    },
   },
 };

--- a/frontend/src/components/InstalledPackages/InstalledPackagesHeader.stories.tsx
+++ b/frontend/src/components/InstalledPackages/InstalledPackagesHeader.stories.tsx
@@ -1,60 +1,54 @@
-// InstalledPackagesHeader.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import InstalledPackagesHeader from "./InstalledPackagesHeader";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "InstalledPackagesHeader",
   component: InstalledPackagesHeader,
-} as ComponentMeta<typeof InstalledPackagesHeader>;
+} satisfies Meta<typeof InstalledPackagesHeader>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof InstalledPackagesHeader> = (args) => (
-  <InstalledPackagesHeader {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  filteredReleases: [
-    {
-      id: "",
-      name: "",
-      namespace: "",
-      revision: 1,
-      updated: "",
-      status: "",
-      chart: "",
-      chart_name: "",
-      chart_ver: "",
-      app_version: "",
-      icon: "",
-      description: "",
-      has_tests: false,
-      chartName: "", // duplicated in some cases in the backend, we need to resolve this
-      chartVersion: "", // duplicated in some cases in the
-    },
-    {
-      id: "",
-      name: "",
-      namespace: "",
-      revision: 1,
-      updated: "",
-      status: "",
-      chart: "",
-      chart_name: "",
-      chart_ver: "",
-      app_version: "",
-      icon: "",
-      description: "",
-      has_tests: false,
-      chartName: "", // duplicated in some cases in the backend, we need to resolve this
-      chartVersion: "", // duplicated in some cases in the
-    },
-  ],
+export const Default = {
+  args: {
+    filteredReleases: [
+      {
+        id: "",
+        name: "",
+        namespace: "",
+        revision: 1,
+        updated: "",
+        status: "",
+        chart: "",
+        chart_name: "",
+        chart_ver: "",
+        app_version: "",
+        icon: "",
+        description: "",
+        has_tests: false,
+        chartName: "", // duplicated in some cases in the backend, we need to resolve this
+        chartVersion: "", // duplicated in some cases in the
+      },
+      {
+        id: "",
+        name: "",
+        namespace: "",
+        revision: 1,
+        updated: "",
+        status: "",
+        chart: "",
+        chart_name: "",
+        chart_ver: "",
+        app_version: "",
+        icon: "",
+        description: "",
+        has_tests: false,
+        chartName: "", // duplicated in some cases in the backend, we need to resolve this
+        chartVersion: "", // duplicated in some cases in the
+      },
+    ],
+  },
 };

--- a/frontend/src/components/InstalledPackages/InstalledPackagesList.stories.tsx
+++ b/frontend/src/components/InstalledPackages/InstalledPackagesList.stories.tsx
@@ -1,60 +1,54 @@
-// InstalledPackagesList.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import InstalledPackagesList from "./InstalledPackagesList";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "InstalledPackagesList",
   component: InstalledPackagesList,
-} as ComponentMeta<typeof InstalledPackagesList>;
+} satisfies Meta<typeof InstalledPackagesList>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof InstalledPackagesList> = (args) => (
-  <InstalledPackagesList {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  installedReleases: [
-    {
-      id: "",
-      name: "",
-      namespace: "",
-      revision: 1,
-      updated: "",
-      status: "",
-      chart: "",
-      chart_name: "",
-      chart_ver: "",
-      app_version: "",
-      icon: "",
-      description: "",
-      has_tests: false,
-      chartName: "", // duplicated in some cases in the backend, we need to resolve this
-      chartVersion: "", // duplicated in some cases in the
-    },
-    {
-      id: "",
-      name: "",
-      namespace: "",
-      revision: 1,
-      updated: "",
-      status: "",
-      chart: "",
-      chart_name: "",
-      chart_ver: "",
-      app_version: "",
-      icon: "",
-      description: "",
-      has_tests: false,
-      chartName: "", // duplicated in some cases in the backend, we need to resolve this
-      chartVersion: "", // duplicated in some cases in the
-    },
-  ],
+export const Default = {
+  args: {
+    installedReleases: [
+      {
+        id: "",
+        name: "",
+        namespace: "",
+        revision: 1,
+        updated: "",
+        status: "",
+        chart: "",
+        chart_name: "",
+        chart_ver: "",
+        app_version: "",
+        icon: "",
+        description: "",
+        has_tests: false,
+        chartName: "", // duplicated in some cases in the backend, we need to resolve this
+        chartVersion: "", // duplicated in some cases in the
+      },
+      {
+        id: "",
+        name: "",
+        namespace: "",
+        revision: 1,
+        updated: "",
+        status: "",
+        chart: "",
+        chart_name: "",
+        chart_ver: "",
+        app_version: "",
+        icon: "",
+        description: "",
+        has_tests: false,
+        chartName: "", // duplicated in some cases in the backend, we need to resolve this
+        chartVersion: "", // duplicated in some cases in the
+      },
+    ],
+  },
 };

--- a/frontend/src/components/SelectMenu.stories.tsx
+++ b/frontend/src/components/SelectMenu.stories.tsx
@@ -7,32 +7,29 @@
  * The default story renders the component with the default props.
  */
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import SelectMenu, { SelectMenuItem, SelectMenuProps } from "./SelectMenu";
+import { Meta } from "@storybook/react";
+import SelectMenu, { SelectMenuItem } from "./SelectMenu";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "SelectMenu",
   component: SelectMenu,
-} as ComponentMeta<typeof SelectMenu>;
+} satisfies Meta<typeof SelectMenu>;
 
-//👇 We create a "template" of how args map to rendering
-const Template: ComponentStory<typeof SelectMenu> = (args: SelectMenuProps) => (
-  <SelectMenu {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-Default.args = {
-  header: "Header",
-  children: [
-    <SelectMenuItem label="Item 1" id={1} key="item1" />,
-    <SelectMenuItem label="Item 2" id={2} key="item2" />,
-    <SelectMenuItem label="Item 3" id={3} key="item3" />,
-  ],
-  selected: 1,
-  onSelect: (id: number) => console.log(id),
+export const Default = {
+  args: {
+    header: "Header",
+    children: [
+      <SelectMenuItem label="Item 1" id={1} key="item1" />,
+      <SelectMenuItem label="Item 2" id={2} key="item2" />,
+      <SelectMenuItem label="Item 3" id={3} key="item3" />,
+    ],
+    selected: 1,
+    onSelect: (id: number) => console.log(id),
+  },
 };

--- a/frontend/src/components/ShutDownButton.stories.tsx
+++ b/frontend/src/components/ShutDownButton.stories.tsx
@@ -1,21 +1,20 @@
-// TabsBar.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import ShutDownButton from "./ShutDownButton";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "ShutDownButton",
   component: ShutDownButton,
-} as ComponentMeta<typeof ShutDownButton>;
+} satisfies Meta<typeof ShutDownButton>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof ShutDownButton> = () => (
-  <ShutDownButton />
-);
+const Template: StoryFn<typeof ShutDownButton> = () => <ShutDownButton />;
 
-export const Default = Template.bind({});
+export const Default = {
+  render: Template,
+};

--- a/frontend/src/components/Tabs.stories.tsx
+++ b/frontend/src/components/Tabs.stories.tsx
@@ -1,22 +1,16 @@
-// TabsBar.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import Tabs from "./Tabs";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "Tabs",
   component: Tabs,
-} as ComponentMeta<typeof Tabs>;
+} satisfies Meta<typeof Tabs>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof Tabs> = (args) => <Tabs {...args} />;
-
-export const Default = Template.bind({});
+export default meta;
 
 const defaultArgs = {
   tabs: [
@@ -35,5 +29,6 @@ const defaultArgs = {
   ],
 };
 
-//@ts-ignore
-Default.args = defaultArgs;
+export const Default = {
+  args: defaultArgs,
+};

--- a/frontend/src/components/TabsBar.stories.tsx
+++ b/frontend/src/components/TabsBar.stories.tsx
@@ -1,39 +1,33 @@
-// TabsBar.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import TabsBar from "./TabsBar";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "TabsBar",
   component: TabsBar,
-} as ComponentMeta<typeof TabsBar>;
+} satisfies Meta<typeof TabsBar>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof TabsBar> = (args) => (
-  <TabsBar {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  tabs: [
-    {
-      name: "tab1",
-      component: <div className="w-250 h-250 bg-green-400">tab1</div>,
-    },
-    {
-      name: "tab2",
-      component: <div className="w-250 h-250 bg-red-400">tab2</div>,
-    },
-    {
-      name: "tab3",
-      component: <div className="w-250 h-250 bg-blue-400">tab3</div>,
-    },
-  ],
-  activeTab: "tab1",
+export const Default = {
+  args: {
+    tabs: [
+      {
+        name: "tab1",
+        component: <div className="w-250 h-250 bg-green-400">tab1</div>,
+      },
+      {
+        name: "tab2",
+        component: <div className="w-250 h-250 bg-red-400">tab2</div>,
+      },
+      {
+        name: "tab3",
+        component: <div className="w-250 h-250 bg-blue-400">tab3</div>,
+      },
+    ],
+    activeTab: "tab1",
+  },
 };

--- a/frontend/src/components/TextInput.stories.tsx
+++ b/frontend/src/components/TextInput.stories.tsx
@@ -4,27 +4,24 @@
  * the first story simply renders the component with the default props.
  */
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
-import TextInput, { TextInputProps } from "./TextInput";
+import { Meta } from "@storybook/react";
+import TextInput from "./TextInput";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "TextInput",
   component: TextInput,
-} as ComponentMeta<typeof TextInput>;
+} satisfies Meta<typeof TextInput>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof TextInput> = (args: TextInputProps) => (
-  <TextInput {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-Default.args = {
-  label: "Label",
-  placeholder: "Placeholder",
-  isMandatory: false,
+export const Default = {
+  args: {
+    label: "Label",
+    placeholder: "Placeholder",
+    isMandatory: false,
+  },
 };

--- a/frontend/src/components/Troubleshoot.stories.tsx
+++ b/frontend/src/components/Troubleshoot.stories.tsx
@@ -1,10 +1,15 @@
 import { Meta, StoryFn } from "@storybook/react";
 import { Troubleshoot } from "./Troubleshoot";
 
-export default {
+const meta = {
   title: "Troubleshoot",
   component: Troubleshoot,
-} as Meta<typeof Troubleshoot>;
+} satisfies Meta<typeof Troubleshoot>;
+
+export default meta;
 
 const Template: StoryFn<typeof Troubleshoot> = () => <Troubleshoot />;
-export const Default = Template.bind({});
+
+export const Default = {
+  render: Template,
+};

--- a/frontend/src/components/common/Button/Button.stories.tsx
+++ b/frontend/src/components/common/Button/Button.stories.tsx
@@ -1,40 +1,42 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Button } from "./Button";
 
 // More on default export: https://storybook.js.org/docs/react/writing-stories/introduction#default-export
-export default {
+const meta = {
   title: "Example/Button",
   component: Button,
   // More on argTypes: https://storybook.js.org/docs/react/api/argtypes
   argTypes: {
     backgroundColor: { control: "color" },
   },
-} as ComponentMeta<typeof Button>;
+} satisfies Meta<typeof Button>;
 
-// More on component templates: https://storybook.js.org/docs/react/writing-stories/introduction#using-args
-const Template: ComponentStory<typeof Button> = (args) => <Button {...args} />;
+export default meta;
 
-export const Primary = Template.bind({});
-// More on args: https://storybook.js.org/docs/react/writing-stories/args
-Primary.args = {
-  primary: true,
-  label: "Button",
+export const Primary = {
+  args: {
+    primary: true,
+    label: "Button",
+  },
 };
 
-export const Secondary = Template.bind({});
-Secondary.args = {
-  label: "Button",
+export const Secondary = {
+  args: {
+    label: "Button",
+  },
 };
 
-export const Large = Template.bind({});
-Large.args = {
-  size: "large",
-  label: "Button",
+export const Large = {
+  args: {
+    size: "large",
+    label: "Button",
+  },
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  size: "small",
-  label: "Button",
+export const Small = {
+  args: {
+    size: "small",
+    label: "Button",
+  },
 };

--- a/frontend/src/components/common/DropDown.stories.tsx
+++ b/frontend/src/components/common/DropDown.stories.tsx
@@ -1,35 +1,29 @@
-/* eslint-disable no-console */
-// DropDown.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import DropDown from "./DropDown";
 import { BsSlack, BsGithub } from "react-icons/bs";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "DropDown",
   component: DropDown,
-} as ComponentMeta<typeof DropDown>;
+} as Meta<typeof DropDown>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof DropDown> = (args) => (
-  <DropDown {...args} />
-);
-
-export const Default = Template.bind({});
+export default meta;
 
 const onClick = () => {
+  // eslint-disable-next-line no-console
   console.log("drop down clicked");
 };
 
-Default.args = {
-  items: [
-    { id: "1", text: "Menu Item 1", onClick: onClick, icon: <BsSlack /> },
-    { id: "2 ", isSeparator: true },
-    { id: "3", text: "Menu Item 3", isDisabled: true, icon: <BsGithub /> },
-  ],
+export const Default = {
+  args: {
+    items: [
+      { id: "1", text: "Menu Item 1", onClick: onClick, icon: <BsSlack /> },
+      { id: "2 ", isSeparator: true },
+      { id: "3", text: "Menu Item 3", isDisabled: true, icon: <BsGithub /> },
+    ],
+  },
 };

--- a/frontend/src/components/common/Header/Header.stories.tsx
+++ b/frontend/src/components/common/Header/Header.stories.tsx
@@ -1,24 +1,26 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 
 import { Header } from "./Header";
 
-export default {
+const meta = {
   title: "Example/Header",
   component: Header,
   parameters: {
     // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
     layout: "fullscreen",
   },
-} as ComponentMeta<typeof Header>;
+} satisfies Meta<typeof Header>;
 
-const Template: ComponentStory<typeof Header> = (args) => <Header {...args} />;
+export default meta;
 
-export const LoggedIn = Template.bind({});
-LoggedIn.args = {
-  user: {
-    name: "Jane Doe",
+export const LoggedIn = {
+  args: {
+    user: {
+      name: "Jane Doe",
+    },
   },
 };
 
-export const LoggedOut = Template.bind({});
-LoggedOut.args = {};
+export const LoggedOut = {
+  args: {},
+};

--- a/frontend/src/components/common/Page/Page.stories.tsx
+++ b/frontend/src/components/common/Page/Page.stories.tsx
@@ -1,25 +1,24 @@
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta, StoryObj } from "@storybook/react";
 import { within, userEvent } from "@storybook/testing-library";
 import { Page } from "./Page";
 
-export default {
+const meta = {
   title: "Example/Page",
   component: Page,
   parameters: {
     // More on Story layout: https://storybook.js.org/docs/react/configure/story-layout
     layout: "fullscreen",
   },
-} as ComponentMeta<typeof Page>;
+} satisfies Meta<typeof Page>;
 
-const Template: ComponentStory<typeof Page> = (args) => <Page {...args} />;
+export default meta;
 
-export const LoggedOut = Template.bind({});
+export const LoggedOut = {};
 
-export const LoggedIn = Template.bind({});
-
-// More on interaction testing: https://storybook.js.org/docs/react/writing-tests/interaction-testing
-LoggedIn.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  const loginButton = await canvas.getByRole("button", { name: /Log in/i });
-  await userEvent.click(loginButton);
+export const LoggedIn: StoryObj<typeof Page> = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const loginButton = await canvas.getByRole("button", { name: /Log in/i });
+    await userEvent.click(loginButton);
+  },
 };

--- a/frontend/src/components/common/StatusLabel.stories.tsx
+++ b/frontend/src/components/common/StatusLabel.stories.tsx
@@ -1,39 +1,37 @@
-import { ComponentStory } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import StatusLabel, { DeploymentStatus } from "./StatusLabel";
 
-export default {
+const meta = {
   title: "StatusLabel",
   component: StatusLabel,
+} satisfies Meta<typeof StatusLabel>;
+
+export default meta;
+
+export const Deployed = {
+  args: {
+    status: DeploymentStatus.DEPLOYED,
+    isRollback: false,
+  },
 };
 
-const Template: ComponentStory<typeof StatusLabel> = (args) => (
-  <StatusLabel {...args} />
-);
-
-export const Deployed = Template.bind({});
-
-Deployed.args = {
-  status: DeploymentStatus.DEPLOYED,
-  isRollback: false,
+export const Failed = {
+  args: {
+    status: DeploymentStatus.FAILED,
+    isRollback: false,
+  },
 };
 
-export const Failed = Template.bind({});
-
-Failed.args = {
-  status: DeploymentStatus.FAILED,
-  isRollback: false,
+export const Pending = {
+  args: {
+    status: DeploymentStatus.PENDING,
+    isRollback: false,
+  },
 };
 
-export const Pending = Template.bind({});
-
-Pending.args = {
-  status: DeploymentStatus.PENDING,
-  isRollback: false,
-};
-
-export const Superseded = Template.bind({});
-
-Superseded.args = {
-  status: DeploymentStatus.SUPERSEDED,
-  isRollback: false,
+export const Superseded = {
+  args: {
+    status: DeploymentStatus.SUPERSEDED,
+    isRollback: false,
+  },
 };

--- a/frontend/src/components/modal/AddRepositoryModal.stories.tsx
+++ b/frontend/src/components/modal/AddRepositoryModal.stories.tsx
@@ -1,25 +1,26 @@
-// Modal.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import AddRepositoryModal from "./AddRepositoryModal";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "AddRepositoryModal",
   component: AddRepositoryModal,
-} as ComponentMeta<typeof AddRepositoryModal>;
+} satisfies Meta<typeof AddRepositoryModal>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof AddRepositoryModal> = (args) => (
+const Template: StoryFn<typeof AddRepositoryModal> = (args) => (
   <AddRepositoryModal {...args} isOpen={true} />
 );
 
-export const Default = Template.bind({});
+export const Default = {
+  render: Template,
 
-Default.args = {
-  isOpen: true,
+  args: {
+    isOpen: true,
+  },
 };

--- a/frontend/src/components/modal/ErrorModal.stories.tsx
+++ b/frontend/src/components/modal/ErrorModal.stories.tsx
@@ -1,31 +1,25 @@
 /* eslint-disable no-console */
-// Modal.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import ErrorModal from "./ErrorModal";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "ErrorModal",
   component: ErrorModal,
-} as ComponentMeta<typeof ErrorModal>;
+} satisfies Meta<typeof ErrorModal>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof ErrorModal> = (args) => (
-  <ErrorModal {...args} />
-);
+export default meta;
 
-export const Default = Template.bind({});
-
-Default.args = {
-  onClose: () => {
-    console.log("on Close clicked");
+export const Default = {
+  args: {
+    onClose: () => {
+      console.log("on Close clicked");
+    },
+    titleText: "Failed to get list of charts",
+    contentText:
+      "failed to get list of releases, cause: Kubernetes cluster unreachable: Get &#34;https://kubernetes.docker.internal:6443/version&#34;: dial tcp 127.0.0.1:6443: connectex: No connection could be made because the target machine actively refused it.",
   },
-  titleText: "Failed to get list of charts",
-  contentText:
-    "failed to get list of releases, cause: Kubernetes cluster unreachable: Get &#34;https://kubernetes.docker.internal:6443/version&#34;: dial tcp 127.0.0.1:6443: connectex: No connection could be made because the target machine actively refused it.",
 };

--- a/frontend/src/components/modal/Modal.stories.tsx
+++ b/frontend/src/components/modal/Modal.stories.tsx
@@ -1,25 +1,22 @@
 /* eslint-disable no-console */
-// Modal.stories.ts|tsx
-
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryObj, StoryFn, Meta } from "@storybook/react";
 import Modal, { ModalAction, ModalButtonStyle } from "./Modal";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "Modal",
   component: Modal,
-} as ComponentMeta<typeof Modal>;
+} satisfies Meta<typeof Modal>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof Modal> = (args) => (
+const Template: StoryFn<typeof Modal> = (args) => (
   <Modal {...args}>Basic text content</Modal>
 );
-
-export const Default = Template.bind({});
 
 const confirmModalActions: ModalAction[] = [
   {
@@ -39,10 +36,14 @@ const confirmModalActions: ModalAction[] = [
   },
 ];
 
-Default.args = {
-  title: "Basic text title",
-  isOpen: true,
-  actions: confirmModalActions,
+export const Default = {
+  render: Template,
+
+  args: {
+    title: "Basic text title",
+    isOpen: true,
+    actions: confirmModalActions,
+  },
 };
 
 const customModalActions: ModalAction[] = [
@@ -65,52 +66,55 @@ const customModalActions: ModalAction[] = [
   },
 ];
 
-export const CustomModal: ComponentStory<typeof Modal> = (args) => (
-  <Modal {...args}>
-    <div>
-      <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
-        Custom Modal Content
-      </p>
-      <button
-        className="bg-cyan-500 p-2"
-        type="button"
-        onClick={() => console.log("just a button")}
-      >
-        Just a button
-      </button>
-    </div>
-  </Modal>
-);
-
-CustomModal.args = {
-  title: (
-    <div>
-      Custom <span className="text-red-500"> Title</span>
-    </div>
+export const CustomModal: StoryObj<typeof Modal> = {
+  render: (args) => (
+    <Modal {...args}>
+      <div>
+        <p className="text-base leading-relaxed text-gray-500 dark:text-gray-400">
+          Custom Modal Content
+        </p>
+        <button
+          className="bg-cyan-500 p-2"
+          type="button"
+          onClick={() => console.log("just a button")}
+        >
+          Just a button
+        </button>
+      </div>
+    </Modal>
   ),
-  isOpen: true,
-  actions: customModalActions,
+
+  args: {
+    title: (
+      <div>
+        Custom <span className="text-red-500"> Title</span>
+      </div>
+    ),
+    isOpen: true,
+    actions: customModalActions,
+  },
 };
 
-export const AutoScrollWhenContentIsMoreThan500Height: ComponentStory<
-  typeof Modal
-> = (args) => (
-  <Modal {...args}>
-    <div
-      style={{
-        height: "1000px",
-        width: "50%",
-        backgroundColor: "skyblue",
-      }}
-    >
-      This div height is 1000 px so we can see a vertical scroll to the right of
-      it.
-    </div>
-  </Modal>
-);
+export const AutoScrollWhenContentIsMoreThan500Height: StoryObj<typeof Modal> =
+  {
+    render: (args) => (
+      <Modal {...args}>
+        <div
+          style={{
+            height: "1000px",
+            width: "50%",
+            backgroundColor: "skyblue",
+          }}
+        >
+          This div height is 1000 px so we can see a vertical scroll to the
+          right of it.
+        </div>
+      </Modal>
+    ),
 
-AutoScrollWhenContentIsMoreThan500Height.args = {
-  title: "Auto Scroll when content is more than 500px height",
-  isOpen: true,
-  actions: confirmModalActions,
-};
+    args: {
+      title: "Auto Scroll when content is more than 500px height",
+      isOpen: true,
+      actions: confirmModalActions,
+    },
+  };

--- a/frontend/src/components/repository/ChartViewer.stories.tsx
+++ b/frontend/src/components/repository/ChartViewer.stories.tsx
@@ -1,6 +1,6 @@
 // ChartViewer.stories.ts|tsx
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import ChartViewer from "./ChartViewer";
 
 //👇 This default export determines where your story goes in the story list
@@ -11,14 +11,11 @@ export default {
    */
   title: "ChartViewer",
   component: ChartViewer,
-} as ComponentMeta<typeof ChartViewer>;
+} as Meta<typeof ChartViewer>;
 
-//👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof ChartViewer> = (args) => (
-  <ChartViewer {...args} />
-);
-
-export const Default = Template.bind({});
+export const Default = {
+  args: defaultArgs,
+};
 
 const defaultArgs = {
   chart: {
@@ -27,6 +24,3 @@ const defaultArgs = {
     version: "v1.0.0",
   },
 };
-
-//@ts-ignore
-Default.args = defaultArgs;

--- a/frontend/src/components/repository/ChartViewer.stories.tsx
+++ b/frontend/src/components/repository/ChartViewer.stories.tsx
@@ -1,21 +1,17 @@
-// ChartViewer.stories.ts|tsx
-
-import { StoryFn, Meta } from "@storybook/react";
+import { Meta } from "@storybook/react";
 import ChartViewer from "./ChartViewer";
 
 //👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "ChartViewer",
   component: ChartViewer,
-} as Meta<typeof ChartViewer>;
+} satisfies Meta<typeof ChartViewer>;
 
-export const Default = {
-  args: defaultArgs,
-};
+export default meta;
 
 const defaultArgs = {
   chart: {
@@ -23,4 +19,8 @@ const defaultArgs = {
     description: "chart1 description",
     version: "v1.0.0",
   },
+};
+
+export const Default = {
+  args: defaultArgs,
 };

--- a/frontend/src/components/repository/RepositoriesList.stories.tsx
+++ b/frontend/src/components/repository/RepositoriesList.stories.tsx
@@ -1,17 +1,16 @@
-// RepositoriesList.stories.ts|tsx
-
 import { StoryFn, Meta } from "@storybook/react";
 import RepositoriesList from "./RepositoriesList";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "RepositoriesList",
   component: RepositoriesList,
-} as Meta<typeof RepositoriesList>;
+} satisfies Meta<typeof RepositoriesList>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: StoryFn<typeof RepositoriesList> = () => (

--- a/frontend/src/components/repository/RepositoriesList.stories.tsx
+++ b/frontend/src/components/repository/RepositoriesList.stories.tsx
@@ -1,6 +1,6 @@
 // RepositoriesList.stories.ts|tsx
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import RepositoriesList from "./RepositoriesList";
 
 //👇 This default export determines where your story goes in the story list
@@ -11,10 +11,10 @@ export default {
    */
   title: "RepositoriesList",
   component: RepositoriesList,
-} as ComponentMeta<typeof RepositoriesList>;
+} as Meta<typeof RepositoriesList>;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof RepositoriesList> = () => (
+const Template: StoryFn<typeof RepositoriesList> = () => (
   <RepositoriesList
     selectedRepository={undefined}
     // in this case we allow Unexpected empty method
@@ -24,4 +24,6 @@ const Template: ComponentStory<typeof RepositoriesList> = () => (
   />
 );
 
-export const Default = Template.bind({});
+export const Default = {
+  render: Template,
+};

--- a/frontend/src/components/repository/RepositoryViewer.stories.tsx
+++ b/frontend/src/components/repository/RepositoryViewer.stories.tsx
@@ -1,17 +1,16 @@
-// RepositoryViewer.stories.ts|tsx
-
 import { StoryFn, Meta } from "@storybook/react";
 import RepositoryViewer from "./RepositoryViewer";
 
-//👇 This default export determines where your story goes in the story list
-export default {
+const meta = {
   /* 👇 The title prop is optional.
    * See https://storybook.js.org/docs/react/configure/overview#configure-story-loading
    * to learn how to generate automatic titles
    */
   title: "RepositoryViewer",
   component: RepositoryViewer,
-} as Meta<typeof RepositoryViewer>;
+} satisfies Meta<typeof RepositoryViewer>;
+
+export default meta;
 
 //👇 We create a “template” of how args map to rendering
 const Template: StoryFn<typeof RepositoryViewer> = () => (

--- a/frontend/src/components/repository/RepositoryViewer.stories.tsx
+++ b/frontend/src/components/repository/RepositoryViewer.stories.tsx
@@ -1,6 +1,6 @@
 // RepositoryViewer.stories.ts|tsx
 
-import { ComponentStory, ComponentMeta } from "@storybook/react";
+import { StoryFn, Meta } from "@storybook/react";
 import RepositoryViewer from "./RepositoryViewer";
 
 //👇 This default export determines where your story goes in the story list
@@ -11,11 +11,13 @@ export default {
    */
   title: "RepositoryViewer",
   component: RepositoryViewer,
-} as ComponentMeta<typeof RepositoryViewer>;
+} as Meta<typeof RepositoryViewer>;
 
 //👇 We create a “template” of how args map to rendering
-const Template: ComponentStory<typeof RepositoryViewer> = () => (
+const Template: StoryFn<typeof RepositoryViewer> = () => (
   <RepositoryViewer repository={undefined} />
 );
 
-export const Default = Template.bind({});
+export const Default = {
+  render: Template,
+};


### PR DESCRIPTION
## Changes Proposed

Basically, no component changes were made and the migration was done using Storybook's migration commands.

The parts that were updated manually are as follows

- Deletion of unnecessary modules loaded when the migration command was executed
- Type storage to resolve type errors


Details are left in the issue

https://github.com/komodorio/helm-dashboard/issues/486

## Check List

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] The title of my pull request is a short description of the changes
- [x] This PR relates to some issue: <!-- use "Closes #999" to auto-close related issue -->
- [x] I have documented the changes made (if applicable)
- ~[ ] I have covered the changes with unit tests~
  - Not supported as it is an unaffected area.

