### PR TITLE
feat: Set history-max through env HELM_MAX_HISTORY (default 10)

### DIFF
--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -199,6 +199,7 @@ func NewHelmConfig(origSettings *cli.EnvSettings, ns string) (*action.Configurat
 		helmDriver, log.Debugf); err != nil {
 		return nil, errorx.Decorate(err, "failed to init Helm action config")
 	}
+	actionConfig.Releases.MaxHistory = origSettings.MaxHistory
 
 	return actionConfig, nil
 }


### PR DESCRIPTION
## Changes Proposed

The number of historical release versions should not be unlimited. Refer to the official settings of Helm, set to 10 and can be configured through env `HELM_MAX_HISTORY`.

## Check List

- [x] The title of my pull request is a short description of the changes
- [ ] This PR relates to some issue: <!-- use "Closes #999" to auto-close related issue -->
- [ ] I have documented the changes made (if applicable)
- [ ] I have covered the changes with unit tests

