### PR TITLE
fix: history-max does not work when exec helm upgrade

### DIFF
--- a/pkg/dashboard/objects/releases.go
+++ b/pkg/dashboard/objects/releases.go
@@ -330,6 +330,7 @@ func (r *Release) Upgrade(repoChart string, version string, justTemplate bool, v
 	}
 
 	cmd := action.NewUpgrade(hc)
+	cmd.MaxHistory = r.Settings.MaxHistory
 
 	cmd.Namespace = r.Settings.Namespace()
 	cmd.Version = version

--- a/pkg/dashboard/server.go
+++ b/pkg/dashboard/server.go
@@ -199,7 +199,6 @@ func NewHelmConfig(origSettings *cli.EnvSettings, ns string) (*action.Configurat
 		helmDriver, log.Debugf); err != nil {
 		return nil, errorx.Decorate(err, "failed to init Helm action config")
 	}
-	actionConfig.Releases.MaxHistory = origSettings.MaxHistory
 
 	return actionConfig, nil
 }


### PR DESCRIPTION
## Changes Proposed

Changes made in #500 did not work properly because the local variable `--history-max` of the cmd `helm upgrade` has a higher priority than the global one.

## Check List

- [x] The title of my pull request is a short description of the changes
- [ ] This PR relates to some issue: <!-- use "Closes #999" to auto-close related issue -->
- [ ] I have documented the changes made (if applicable)
- [ ] I have covered the changes with unit tests

