### PR TITLE
Added ability to disable query to ArtifactHub via env

### DIFF
--- a/pkg/dashboard/handlers/helmHandlers.go
+++ b/pkg/dashboard/handlers/helmHandlers.go
@@ -241,6 +241,11 @@ func (h *HelmHandler) RepoLatestVer(c *gin.Context) {
 	if len(res) > 0 {
 		c.IndentedJSON(http.StatusOK, res[:1])
 	} else {
+		if utils.EnvAsBool("HD_NO_ARTIFACT_HUB_QUERY", false) {
+			c.Status(http.StatusNoContent)
+			return
+		}
+
 		// caching it to avoid too many requests
 		found, err := h.Data.Cache.String("chart-artifacthub-query/"+qp.Name, nil, func() (string, error) {
 			return h.repoFromArtifactHub(qp.Name)


### PR DESCRIPTION
It is now possible to disable the query through environment variable HD_NO_ARTIFACT_HUB_QUERY.

## Changes Proposed

<!-- Describe the proposed changes and any additional information -->
As suggested by @undera in #506 

<!-- Add all the screenshots which illustrate your changes -->

## Check List

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] The title of my pull request is a short description of the changes
- [x] This PR relates to some issue: Closes #506<!-- use "Closes #999" to auto-close related issue -->
- [ ] I have documented the changes made (if applicable)
- [ ] I have covered the changes with unit tests

