### PR TITLE
Fix resource status not enhanced for calls to /api/k8s/{kind}/get route

### DIFF
--- a/pkg/dashboard/handlers/kubeHandlers.go
+++ b/pkg/dashboard/handlers/kubeHandlers.go
@@ -1,6 +1,8 @@
 package handlers
 
 import (
+	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/joomcode/errorx"
 	"github.com/komodorio/helm-dashboard/pkg/dashboard/utils"
@@ -8,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	v12 "k8s.io/apimachinery/pkg/apis/testapigroup/v1"
 	"k8s.io/utils/strings/slices"
-	"net/http"
 )
 
 const Unknown = "Unknown"
@@ -56,7 +57,7 @@ func (h *KubeHandler) GetResourceInfo(c *gin.Context) {
 		return
 	}
 
-	EnhanceStatus(res, nil)
+	res.Status = *EnhanceStatus(res, nil)
 
 	c.IndentedJSON(http.StatusOK, res)
 }


### PR DESCRIPTION
## Changes Proposed

<!-- Describe the proposed changes and any additional information -->

The pointer address returned from EnhanceStatus is now correctly set, following the same structure adopted in Resources function of /pkg/dashboard/handlers/helmHandlers.go

<!-- Add all the screenshots which illustrate your changes -->

## Check List

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

- [x] The title of my pull request is a short description of the changes
- [x] This PR relates to some issue: Closes #516<!-- use "Closes #999" to auto-close related issue -->
- [ ] I have documented the changes made (if applicable)
- [ ] I have covered the changes with unit tests

