### PR TITLE
Add digest field to image block in values.yaml

### DIFF
--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -17,6 +17,8 @@ image:
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
+  # Specifies the exact image digest to pull.
+  digest: ""
   imagePullSecrets: []
 
 nameOverride: ""


### PR DESCRIPTION
This pull request adds a `digest` field to the `image` block in the `values.yaml` file. The `digest` field allows specifying the exact image digest to pull, ensuring that the correct image version is used. 

Changes include:
- Added `digest` field to the `image` block in `values.yaml`

This change does not introduce any breaking changes and is backward compatible. The `digest` field is already utilized in the `_helpers.tpl` file, ensuring that the specified digest is used when constructing the image name.