### PR TITLE
Update helm-dashboard.serviceAccountName Template Logic in _helpers.tpl

### DIFF
--- a/charts/helm-dashboard/templates/_helpers.tpl
+++ b/charts/helm-dashboard/templates/_helpers.tpl
@@ -54,11 +54,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 Create the name of the service account to use
 */}}
 {{- define "helm-dashboard.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "helm-dashboard.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
+{{- default (.Values.serviceAccount.create | ternary (include "helm-dashboard.fullname" .) "default") .Values.serviceAccount.name }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
This pull request updates the `helm-dashboard.serviceAccountName` template logic in the `_helpers.tpl` file to improve the handling of service account names. The changes include:

- Utilizing the `default` function to set the service account name based on the `serviceAccount.create` value.
- Ensuring that the service account name is generated using the `helm-dashboard.fullname` template when `serviceAccount.create` is true, otherwise defaulting to "default".
- Maintaining backward compatibility with existing configurations by preserving the use of `.Values.serviceAccount.name`.

These changes enhance the flexibility and robustness of the Helm chart's service account naming conventions.