### PR TITLE
Fix: Handle Cluster Names with Slashes in Helm Dashboard UI

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ const PageLayout = () => {
 const SyncContext: React.FC = () => {
   const { context } = useParams();
   if (context) {
-    apiService.setCluster(context);
+    apiService.setCluster(decodeURIComponent(context));
   }
 
   return <Outlet />;

--- a/frontend/src/pages/Installed.tsx
+++ b/frontend/src/pages/Installed.tsx
@@ -21,7 +21,7 @@ function Installed() {
 
   const handleClusterChange = (clusterName: string) => {
     navigate({
-      pathname: `/${clusterName}/installed`,
+      pathname: `/${encodeURIComponent(clusterName)}/installed`,
     });
   };
 


### PR DESCRIPTION
This PR addresses issue #557 by ensuring that the Helm Dashboard UI is accessible even if the cluster name contains a slash. The changes include:

- Added necessary encoding to the navigation path to prevent routing issues.
- Implemented decoding of cluster names to ensure proper display and functionality.

Closes #557.