### PR TITLE
Add Support for Static LoadBalancer IP in Offline Deployments

### DIFF
--- a/charts/helm-dashboard/templates/service.yaml
+++ b/charts/helm-dashboard/templates/service.yaml
@@ -13,3 +13,6 @@ spec:
       name: http
   selector:
     {{- include "helm-dashboard.selectorLabels" . | nindent 4 }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}

--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -106,6 +106,7 @@ securityContext: {}
 service:
   type: ClusterIP
   port: 8080
+  loadBalancerIP: null
 
 ingress:
   enabled: false


### PR DESCRIPTION
Changes Proposed
This PR introduces the ability to specify a loadBalancerIP for the Service when using the LoadBalancer type. This is particularly useful for offline deployments where a static IP is required for the service to function reliably.

The changes allow users to provide a loadBalancerIP field in the values.yml file, ensuring flexibility for setups in air-gapped or isolated environments. The Service template has been updated to conditionally include this field if it is specified.

Key Changes:
Updated the Service template to support loadBalancerIP.
Modified the values.yml file to include the loadBalancerIP field.
Documented the usage of loadBalancerIP in the values.yml example.
Check List
 V  The title of my pull request is a short description of the changes
 V  This PR relates to some issue
 V  I have documented the changes made (if applicable)
 X  I have covered the changes with unit tests