### PR TITLE
Fix modulepath

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/komodorio/helm-dashboard
+module github.com/komodorio/helm-dashboard/v2
 
 go 1.22
 


### PR DESCRIPTION
## Changes Proposed

If the module is released at major version 2 or higher, the module path must end with a major version suffix like /v2. This may or may not be part of the subdirectory name

See https://go.dev/ref/mod#module-path

Fixing it will enable installing it locally with tools like [mise](https://mise.jdx.dev/) which currently default to the last v1: `mise use go:github.com/komodorio/helm-dashboard`
