### PR TITLE
docs(readme): update repository links and improve helm chart reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ If you want to increase the logging verbosity and see all the debug info, use th
 
 ### Deploying Helm Dashboard on Kubernetes
 
-The official helm chart is [available here](https://github.com/komodorio/helm-charts/blob/master/charts/helm-dashboard)
+The official Helm chart is [available in the Komodor helm-charts repository](https://github.com/komodorio/helm-charts/tree/main/charts/helm-dashboard).
 
 ## Support Channels
 


### PR DESCRIPTION
## Description
Updates outdated `master` branch reference link for the Helm Dashboard chart to `main` and improves formatting in README.md documentation.