### PR TITLE
fix(scripts): cleanup temporary release archives after plugin installation

### DIFF
--- a/scripts/install_plugin.sh
+++ b/scripts/install_plugin.sh
@@ -100,6 +100,9 @@ mkdir -p "releases/v${version}"
 
 install_plugin "$version" "$url" "releases/v${version}.tar.gz" "releases/v${version}"
 
+# Clean up temporary release artifacts
+rm -rf "releases/v${version}.tar.gz" "releases/v${version}"
+
 echo
 echo "Helm Dashboard is installed. To start it, run the following command:"
 echo "helm dashboard"


### PR DESCRIPTION
## Description
Automatically removes leftover temporary archive `releases/v${version}.tar.gz` and temporary extraction directory `releases/v${version}` after successful plugin binary installation in `scripts/install_plugin.sh`.