### PR TITLE
docs(security): add security vulnerability disclosure policy SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,28 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release of Helm Dashboard is actively supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 2.x     | :white_check_mark: |
+| < 2.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take the security of Helm Dashboard seriously. If you believe you have found a security vulnerability in Helm Dashboard, please do NOT open a public GitHub issue.
+
+Instead, please report it privately:
+- Email security issues to: [security@komodor.com](mailto:security@komodor.com)
+- Or contact the team directly via the [Komodor Slack Community](https://komodorkommunity.slack.com).
+
+### Information to Include
+Please include as much of the following information as possible to help us understand and resolve the issue:
+- Description of the vulnerability and potential impact.
+- Step-by-step instructions or proof-of-concept code to reproduce the issue.
+- Affected component or version of Helm Dashboard.
+
+### Response Timeline
+- We will acknowledge receipt of your vulnerability report within 48 hours.
+- We will provide a status update or fix notification once investigated.


### PR DESCRIPTION
## Description
Adds a standard `SECURITY.md` policy detailing supported versions and private vulnerability reporting channels.