### PR TITLE
fix(gitignore): ignore coverage profiles and temporary build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ go.work
 /pkg/dashboard/objects/testdata/hello-world-0.1.0.tgz
 /pkg/frontend/dist/*
 /dist/
+profile.cov
+coverage.out
+*.tmp
+.nx/


### PR DESCRIPTION
## Description
Adds `profile.cov`, `coverage.out`, `*.tmp`, and `.nx/` to `.gitignore` to prevent tracking temporary build and coverage output files.