### PR TITLE
feat(frontend): add typecheck script for non-emitting TypeScript validation

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "pre:commit": "lint-staged",
     "test": "echo \"Error: no test specified. Please use 'cypress:run' or 'cypress:open' commands\" && exit 1",
     "tsc": "tsc",
+    "typecheck": "tsc --noEmit",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build",
     "lint": "npx eslint src/",


### PR DESCRIPTION
## Description
Adds a `typecheck` script (`tsc --noEmit`) to `frontend/package.json` allowing type checking of TypeScript code without producing output files.