### PR TITLE
docs(code-of-conduct): add Slack community channel to enforcement contact info

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,8 +59,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-itiel@komodor.com.
+reported to the community leaders responsible for enforcement via email at
+itiel@komodor.com or through the [Komodor Slack Community](https://komodorkommunity.slack.com).
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the


### PR DESCRIPTION
## Description
Adds the Slack community link to the Enforcement section of `CODE_OF_CONDUCT.md` for consistency with `README.md` and `CONTRIBUTING.md`.