### PR TITLE
[helm-dashboard] Add commonLabels support

### DIFF
--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -39,6 +39,8 @@ resources:
     cpu: 1
     memory: 1Gi
 
+commonLabels: {}
+
 dashboard:
   allowWriteActions: true
 


### PR DESCRIPTION
## What this PR does

Adds `commonLabels` support to the helm-dashboard chart, allowing users to define a set of labels that are applied to all chart-managed resources.

## Why

Teams running helm-dashboard in shared or multi-tenant clusters commonly need to attach labels to all resources for:

- Cost allocation and chargeback (e.g. `team:`, `env:`, `cost-center:`)
- Network policy targeting
- Label-based selectors and queries (e.g. in Prometheus, Grafana, kubectl)
- Compliance and audit requirements

Currently the chart only supports labels on the PersistentVolumeClaim (`dashboard.persistence.labels`). There is no way to label the Deployment, Service, ServiceAccount, Ingress, or pod template without forking the chart.

## Changes

- Add `commonLabels: {}` to `values.yaml`
- Apply the helper to all chart-managed resources:
  - Deployment (metadata + pod template)
  - Service
  - ServiceAccount
  - Ingress

## Usage

```yaml
commonLabels:
  team: platform
  env: production
  cost-center: infra
```

## References

- Similar implementation in prometheus-community charts: https://github.com/prometheus-community/helm-charts/pull/6608
