### PR TITLE
build(deps): bump react-router from 7.15.1 to 7.18.2 in /frontend

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,7 @@
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^10.0.3",
         "react-modern-drawer": "^1.4.0",
-        "react-router": "^7.13.0",
+        "react-router": "^7.18.2",
         "react-select": "^5.10.2",
         "swagger-ui-react": "^5.31.2",
         "uuid": "^14.0.0"
@@ -11174,9 +11174,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.1.tgz",
-      "integrity": "sha512-R8rl9HhgikFYoPJymnUtPXWbnDb3oget6lQnfIoupbt61aT9aOhRkDsY2XRhZRyX1Z/8a5sL74fXmFNm3NRK5A==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -41,7 +41,7 @@
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^10.0.3",
     "react-modern-drawer": "^1.4.0",
-    "react-router": "^7.13.0",
+    "react-router": "^7.18.2",
     "react-select": "^5.10.2",
     "swagger-ui-react": "^5.31.2",
     "uuid": "^14.0.0"


### PR DESCRIPTION
Supersedes #726.

## Why not the v8 major

All four open react-router advisories are patched in **7.18.0**:

| Advisory | Vulnerable range | Patched |
|---|---|---|
| Unauthenticated DoS via inefficient route matching | `>= 7.0.0, < 7.18.0` | 7.18.0 |
| Open redirect via backslash in `<Link>`/`useNavigate` (CVE-2025-68470 bypass) | `>= 6.0.0, < 7.18.0` | 7.18.0 |
| Arbitrary constructor injection via `deserializeErrors()` | `>= 6.4.0, < 7.18.0` | 7.18.0 |
| `RSCErrorHandler` missing protocol validation (XSS) | `>= 7.11.0, < 7.18.0` | 7.18.0 |

Staying on the 7.x line closes all of them with no migration. Dependabot proposed 8.3.0 in #726 because `^7.13.0` does not admit 8.x, not because the major was needed for the fixes.

v8 would additionally require Node `>=22.22.0` and React `>=19.2.7`, drop CommonJS in favour of ESM-only distribution, and move the TypeScript target to ES2022. The migration surface here does look small — the app uses declarative mode only (`HashRouter`/`Routes`/`Route`/`Outlet` plus hooks), imports nothing from `react-router-dom`, and uses none of the removed APIs — but that is a change worth making deliberately rather than as a security response.

## Scope

Only `frontend/package.json` and `frontend/package-lock.json`. `frontend/yarn.lock` is deliberately untouched: npm rewrites it as a side effect of any install, and `release.yaml` already discards those changes via `git checkout frontend/yarn.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)