### PR TITLE
feat(chart): apply commonLabels to all rendered resources

### DIFF
--- a/charts/helm-dashboard/README.md
+++ b/charts/helm-dashboard/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the chart and their def
 | `service.port           `             | Kubernetes service port                                                                        | `8080`                           |
 | `serviceAccount.create`               | Creates a service account                                                                      | `true`                           |
 | `serviceAccount.name`                 | Optional name for the service account                                                          | `{RELEASE_FULLNAME}`             |
+| `commonLabels`                        | Labels to add to all resources managed by this chart                                           | `{}`                             |
 | `nodeSelector`                        | Node labels for pod assignment                                                                 |                                  |
 | `affinity`                            | Affinity settings for pod assignment                                                           |                                  |
 | `tolerations`                         | Tolerations for pod assignment                                                                 |                                  |
@@ -75,6 +76,8 @@ The following table lists the configurable parameters of the chart and their def
 | `dashboard.persistence.accessModes`   | Persistent Volume access modes                                                                 | `["ReadWriteOnce"]`              |
 | `dashboard.persistence.storageClass`  | Persistent Volume storage class                                                                | `""`                             |
 | `dashboard.persistence.size`          | Persistent Volume size                                                                         | `100M`                           |
+| `dashboard.persistence.labels`        | Extra labels for the Persistent Volume Claim                                                   | `{}`                             |
+| `dashboard.persistence.annotations`   | Annotations for the Persistent Volume Claim                                                    | `{}`                             |
 | `dashboard.persistence.finalizers`    | Finalizers for the Persistent Volume Claim                                                     | `[kubernetes.io/pvc-protection]`                             |
 | `dashboard.persistence.lookupVolumeName` | Lookup volume name for the Persistent Volume Claim                                             | `true`                             |
 | `updateStrategy.type`                 | Set up update strategy for helm-dashboard installation.                                        | `RollingUpdate`                  |             

--- a/charts/helm-dashboard/templates/_helpers.tpl
+++ b/charts/helm-dashboard/templates/_helpers.tpl
@@ -33,6 +33,9 @@ helm.sh/chart: {{ include "helm-dashboard.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/helm-dashboard/templates/deployment.yaml
+++ b/charts/helm-dashboard/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       {{- end }}
       labels:
         {{- include "helm-dashboard.selectorLabels" . | nindent 8 }}
+        {{- with .Values.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "helm-dashboard.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "helm-dashboard.serviceAccountName" . }}

--- a/charts/helm-dashboard/templates/pvc.yaml
+++ b/charts/helm-dashboard/templates/pvc.yaml
@@ -6,6 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "helm-dashboard.labels" . | nindent 4 }}
+    {{- with .Values.dashboard.persistence.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.dashboard.persistence.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/helm-dashboard/templates/serviceaccount.yaml
+++ b/charts/helm-dashboard/templates/serviceaccount.yaml
@@ -14,6 +14,8 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "helm-dashboard.serviceAccountName" . }}
+  labels:
+    {{- include "helm-dashboard.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["*"]
     resources: ["*"]
@@ -28,6 +30,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "helm-dashboard.serviceAccountName" . }}
+  labels:
+    {{- include "helm-dashboard.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -39,6 +39,8 @@ resources:
     cpu: 1
     memory: 1Gi
 
+commonLabels: {}
+
 dashboard:
   allowWriteActions: true
 

--- a/charts/helm-dashboard/values.yaml
+++ b/charts/helm-dashboard/values.yaml
@@ -39,6 +39,8 @@ resources:
     cpu: 1
     memory: 1Gi
 
+## Labels to add to all resources managed by this chart
+##
 commonLabels: {}
 
 dashboard:


### PR DESCRIPTION
Supersedes #730 — carries @ashutoshbhardwaj007's original commit and adds the templating that makes the value do something.

### Problem

`commonLabels` was declared in `values.yaml` but referenced by no template, so setting it produced no labels anywhere. `dashboard.persistence.labels` has the same defect: documented in `values.yaml`, used by nothing.

### Change

- `commonLabels` merged into the `helm-dashboard.labels` helper, which every resource already includes
- Deployment pod template gets them too — but **not** `spec.selector.matchLabels`, which is immutable; folding them in there would break `helm upgrade` on existing releases
- ClusterRole and ClusterRoleBinding had no labels at all, so they now get the standard block
- `dashboard.persistence.labels` wired into the PVC
- README rows for `commonLabels`, `dashboard.persistence.labels` and `dashboard.persistence.annotations`

### Verification

`helm lint` clean. With `commonLabels` set, all 8 rendered resources carry them (ServiceAccount, PVC, ClusterRole, ClusterRoleBinding, Service, Deployment metadata + pod template, Ingress, test Pod) while `spec.selector` renders byte-identical to `main`.

Rendered with defaults, the only diff against `main` is the new label block on ClusterRole/ClusterRoleBinding. Keys containing dots and values like `"1.0"` or `""` round-trip correctly through `toYaml`.

Closes #730

🤖 Generated with [Claude Code](https://claude.com/claude-code)