### PR TITLE
fix(docker): pin runtime base to alpine:3.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ WORKDIR /build/src
 RUN make build_go
 
 # Stage - runner
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.24
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM


### PR DESCRIPTION
Addresses #738, reported by @unitmatrix. All the facts in that report check out — verified independently:

| Claim | Result |
|---|---|
| `latest` and `2.1.1` are the same image, pushed 2026-03-27 | ✅ both `sha256:86dd0b7c…` |
| Published `latest` runs Alpine 3.23.3 | ✅ `/etc/alpine-release` → `3.23.3` |
| `unstable` already on 3.24.1 | ✅ |
| `alpine:latest` maps to 3.24.1 | ✅ docker-library catalog |
| `latest` only rebuilt on a `v*` tag | ✅ `release.yaml` is `on: push: tags:` |

### Change

```diff
-FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine
+FROM --platform=${TARGETPLATFORM:-linux/amd64} alpine:3.24
```

### Why the 3.24 branch and not an exact 3.24.1

The issue proposes `alpine:3.24.1`. This repo has no dependabot or renovate config, so an exact pin has nothing to bump it — a release cut next year would still build 3.24.1, trading today's staleness for a slower version of the same bug. The branch pin keeps patch-level security fixes flowing into every build while still removing the real risk of the floating tag, which is a major Alpine bump landing unnoticed in a release build.

`alpine:3.24` resolves to 3.24.1 today, carrying exactly the fixed packages the issue asks for: `musl 1.2.6-r2`, `zlib 1.3.2-r0`, `libcrypto3`/`libssl3 3.5.7-r0`.

### This PR does not fix the published image

`latest` and the version tags are rebuilt only when a `v*` tag is pushed. Merging this changes nothing on Docker Hub until a patch release is cut — that remains the operative fix for the reported exposure.

### Verification

Full `docker build` green. The resulting image reports Alpine 3.24.1 with the package versions above, and `/bin/helm-dashboard --version` runs. `alpine:3.24` publishes `linux/amd64` and `linux/arm64` manifests, matching `platforms: linux/amd64,linux/arm64` in `release.yaml`, so no architecture is dropped.

Out of scope, noted for later: the build stages use `node:latest` and a bare `golang`, also floating. They don't ship (static `CGO_ENABLED=0` binary, multi-stage), so no CVE exposure — build reproducibility only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)