### PR TITLE
fix(ci): restore all tracked files before goreleaser

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,10 @@ jobs:
         with:
           go-version: "1.24"
       - name: git cleanup
-        run: git clean -f && git checkout frontend/yarn.lock
+        # goreleaser refuses to run on a dirty tree. `npm i` rewrites both lockfiles,
+        # so restore everything tracked rather than yarn.lock alone. No -x, to keep
+        # the built pkg/frontend/dist that the binary embeds.
+        run: git checkout -- . && git clean -fd
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:


### PR DESCRIPTION
The `v2.1.2` release run failed at `git is in a dirty state` ([run](https://github.com/komodorio/helm-dashboard/actions/runs/31392187497)). goreleaser aborts during `getting and validating git state`, so no GitHub release was created and the `image` / `publish_chart` jobs were skipped — nothing reached Docker Hub. The tag has since been deleted; this will go out as v2.1.3.

### Root cause

Replaying the release steps on a clean clone of the tagged commit — `npm i` → `npm run build` → `git clean -f && git checkout frontend/yarn.lock` — leaves exactly one dirty path:

```
 M frontend/package-lock.json
```

`npm i` strips `libc` fields from the committed lockfile (48 deletions), because the runner's npm is older than whichever npm wrote it. The cleanup step restored only `frontend/yarn.lock`, which `npm i` also rewrites, so nobody was restoring `package-lock.json`.

This is not a regression from either recent PR — the release path has been broken since some frontend dependency bump landed after v2.1.1 in March.

### Change

```diff
-        run: git clean -f && git checkout frontend/yarn.lock
+        run: git checkout -- . && git clean -fd
```

Restores every tracked file rather than naming one, and `-d` drops untracked directories that plain `-f` leaves behind.

**No `-x`**, deliberately: the built `pkg/frontend/dist` is ignored via `/pkg/frontend/dist/*` and the Go binary embeds it. I verified in a scratch repo that `git clean -fd` leaves a directory whose contents are all ignored intact — with `-x` it would be deleted and the build would fail on the `go:embed`.

### Not fixed here

This workflow pins no `node-version`, so the runner's npm can keep drifting from whichever npm writes the lockfile. Pinning it would stop the rewrite at the source rather than cleaning up after it. Separately, the `release` job checks out shallow — only `pre_release` sets `fetch-depth: 0` — which is why goreleaser warned `couldn't find any tags before "v2.1.2"` and will produce an empty changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)