### PR TITLE
fix(handlers): add nil safety guards for release, chart, info and metadata in HReleaseToJSON and HReleaseToHistElem

### DIFF
--- a/pkg/dashboard/handlers/helmHandlers.go
+++ b/pkg/dashboard/handlers/helmHandlers.go
@@ -681,9 +681,6 @@ type RepoChartElement struct { // TODO: do we need it at all? there is existing 
 }
 
 func HReleaseToJSON(o *release.Release) *ReleaseElement {
-	if o == nil {
-		return nil
-	}
 	res := &ReleaseElement{
 		Name:      o.Name,
 		Namespace: o.Namespace,
@@ -741,9 +738,6 @@ type HistoryElement struct {
 }
 
 func HReleaseToHistElem(o *release.Release) *HistoryElement {
-	if o == nil {
-		return nil
-	}
 	res := &HistoryElement{
 		Revision: o.Version,
 		HasTests: releaseHasTests(o),

--- a/pkg/dashboard/handlers/helmHandlers.go
+++ b/pkg/dashboard/handlers/helmHandlers.go
@@ -681,19 +681,31 @@ type RepoChartElement struct { // TODO: do we need it at all? there is existing 
 }
 
 func HReleaseToJSON(o *release.Release) *ReleaseElement {
-	return &ReleaseElement{
-		Name:         o.Name,
-		Namespace:    o.Namespace,
-		Revision:     strconv.Itoa(o.Version),
-		Updated:      o.Info.LastDeployed,
-		Status:       o.Info.Status,
-		Chart:        fmt.Sprintf("%s-%s", o.Chart.Name(), o.Chart.Metadata.Version),
-		ChartName:    o.Chart.Name(),
-		ChartVersion: o.Chart.Metadata.Version,
-		AppVersion:   o.Chart.AppVersion(),
-		Icon:         o.Chart.Metadata.Icon,
-		Description:  o.Chart.Metadata.Description,
+	if o == nil {
+		return nil
 	}
+	res := &ReleaseElement{
+		Name:      o.Name,
+		Namespace: o.Namespace,
+		Revision:  strconv.Itoa(o.Version),
+	}
+	if o.Info != nil {
+		res.Updated = o.Info.LastDeployed
+		res.Status = o.Info.Status
+	}
+	if o.Chart != nil {
+		res.ChartName = o.Chart.Name()
+		res.AppVersion = o.Chart.AppVersion()
+		if o.Chart.Metadata != nil {
+			res.ChartVersion = o.Chart.Metadata.Version
+			res.Icon = o.Chart.Metadata.Icon
+			res.Description = o.Chart.Metadata.Description
+			res.Chart = fmt.Sprintf("%s-%s", o.Chart.Name(), o.Chart.Metadata.Version)
+		} else {
+			res.Chart = o.Chart.Name()
+		}
+	}
+	return res
 }
 
 type ReleaseElement struct {
@@ -729,17 +741,29 @@ type HistoryElement struct {
 }
 
 func HReleaseToHistElem(o *release.Release) *HistoryElement {
-	return &HistoryElement{
-		Revision:    o.Version,
-		Updated:     o.Info.LastDeployed,
-		Status:      o.Info.Status,
-		Chart:       fmt.Sprintf("%s-%s", o.Chart.Name(), o.Chart.Metadata.Version),
-		AppVersion:  o.Chart.AppVersion(),
-		Description: o.Info.Description,
-		ChartName:   o.Chart.Name(),
-		ChartVer:    o.Chart.Metadata.Version,
-		HasTests:    releaseHasTests(o),
+	if o == nil {
+		return nil
 	}
+	res := &HistoryElement{
+		Revision: o.Version,
+		HasTests: releaseHasTests(o),
+	}
+	if o.Info != nil {
+		res.Updated = o.Info.LastDeployed
+		res.Status = o.Info.Status
+		res.Description = o.Info.Description
+	}
+	if o.Chart != nil {
+		res.ChartName = o.Chart.Name()
+		res.AppVersion = o.Chart.AppVersion()
+		if o.Chart.Metadata != nil {
+			res.ChartVer = o.Chart.Metadata.Version
+			res.Chart = fmt.Sprintf("%s-%s", o.Chart.Name(), o.Chart.Metadata.Version)
+		} else {
+			res.Chart = o.Chart.Name()
+		}
+	}
+	return res
 }
 
 func RevisionDiff(functor objects.SectionFn, ext string, revision1 *release.Release, revision2 *release.Release, flag bool) (string, error) {

--- a/pkg/dashboard/handlers/helmHandlers_test.go
+++ b/pkg/dashboard/handlers/helmHandlers_test.go
@@ -1,0 +1,138 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"helm.sh/helm/v3/pkg/chart"
+	"helm.sh/helm/v3/pkg/release"
+	helmtime "helm.sh/helm/v3/pkg/time"
+)
+
+func TestHReleaseToJSON(t *testing.T) {
+	now := helmtime.Time{Time: time.Now()}
+
+	t.Run("nil release", func(t *testing.T) {
+		res := HReleaseToJSON(nil)
+		if res != nil {
+			t.Errorf("expected nil for nil release, got %v", res)
+		}
+	})
+
+	t.Run("complete release", func(t *testing.T) {
+		rel := &release.Release{
+			Name:      "my-release",
+			Namespace: "default",
+			Version:   1,
+			Info: &release.Info{
+				LastDeployed: now,
+				Status:       release.StatusDeployed,
+			},
+			Chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					Name:        "my-chart",
+					Version:     "1.2.3",
+					AppVersion:  "2.0.0",
+					Icon:        "https://example.com/icon.png",
+					Description: "A sample chart",
+				},
+			},
+		}
+
+		res := HReleaseToJSON(rel)
+		if res == nil {
+			t.Fatal("expected non-nil ReleaseElement")
+		}
+		if res.Name != "my-release" || res.Namespace != "default" || res.Revision != "1" {
+			t.Errorf("unexpected basic fields: %+v", res)
+		}
+		if res.Status != release.StatusDeployed || res.Updated != now {
+			t.Errorf("unexpected Info fields: %+v", res)
+		}
+		if res.Chart != "my-chart-1.2.3" || res.ChartName != "my-chart" || res.ChartVersion != "1.2.3" {
+			t.Errorf("unexpected Chart fields: %+v", res)
+		}
+		if res.AppVersion != "2.0.0" || res.Icon != "https://example.com/icon.png" || res.Description != "A sample chart" {
+			t.Errorf("unexpected metadata fields: %+v", res)
+		}
+	})
+
+	t.Run("nil Info and nil Chart", func(t *testing.T) {
+		rel := &release.Release{
+			Name:      "partial-release",
+			Namespace: "kube-system",
+			Version:   2,
+		}
+
+		res := HReleaseToJSON(rel)
+		if res == nil {
+			t.Fatal("expected non-nil ReleaseElement")
+		}
+		if res.Name != "partial-release" || res.Revision != "2" {
+			t.Errorf("unexpected basic fields: %+v", res)
+		}
+		if res.ChartName != "" || res.ChartVersion != "" {
+			t.Errorf("expected empty chart fields, got: %+v", res)
+		}
+	})
+}
+
+func TestHReleaseToHistElem(t *testing.T) {
+	now := helmtime.Time{Time: time.Now()}
+
+	t.Run("nil release", func(t *testing.T) {
+		res := HReleaseToHistElem(nil)
+		if res != nil {
+			t.Errorf("expected nil for nil release, got %v", res)
+		}
+	})
+
+	t.Run("complete release with tests", func(t *testing.T) {
+		rel := &release.Release{
+			Name:    "my-release",
+			Version: 3,
+			Info: &release.Info{
+				LastDeployed: now,
+				Status:       release.StatusDeployed,
+				Description:  "Install complete",
+			},
+			Chart: &chart.Chart{
+				Metadata: &chart.Metadata{
+					Name:       "my-chart",
+					Version:    "1.0.0",
+					AppVersion: "1.0.0",
+				},
+			},
+			Hooks: []*release.Hook{
+				{
+					Events: []release.HookEvent{release.HookTest},
+				},
+			},
+		}
+
+		res := HReleaseToHistElem(rel)
+		if res == nil {
+			t.Fatal("expected non-nil HistoryElement")
+		}
+		if res.Revision != 3 || res.Description != "Install complete" || !res.HasTests {
+			t.Errorf("unexpected fields: %+v", res)
+		}
+		if res.Chart != "my-chart-1.0.0" || res.ChartName != "my-chart" || res.ChartVer != "1.0.0" {
+			t.Errorf("unexpected chart fields: %+v", res)
+		}
+	})
+
+	t.Run("nil Chart and nil Info", func(t *testing.T) {
+		rel := &release.Release{
+			Version: 1,
+		}
+
+		res := HReleaseToHistElem(rel)
+		if res == nil {
+			t.Fatal("expected non-nil HistoryElement")
+		}
+		if res.Revision != 1 || res.HasTests {
+			t.Errorf("unexpected fields: %+v", res)
+		}
+	})
+}

--- a/pkg/dashboard/handlers/helmHandlers_test.go
+++ b/pkg/dashboard/handlers/helmHandlers_test.go
@@ -12,13 +12,6 @@ import (
 func TestHReleaseToJSON(t *testing.T) {
 	now := helmtime.Time{Time: time.Now()}
 
-	t.Run("nil release", func(t *testing.T) {
-		res := HReleaseToJSON(nil)
-		if res != nil {
-			t.Errorf("expected nil for nil release, got %v", res)
-		}
-	})
-
 	t.Run("complete release", func(t *testing.T) {
 		rel := &release.Release{
 			Name:      "my-release",
@@ -79,13 +72,6 @@ func TestHReleaseToJSON(t *testing.T) {
 
 func TestHReleaseToHistElem(t *testing.T) {
 	now := helmtime.Time{Time: time.Now()}
-
-	t.Run("nil release", func(t *testing.T) {
-		res := HReleaseToHistElem(nil)
-		if res != nil {
-			t.Errorf("expected nil for nil release, got %v", res)
-		}
-	})
 
 	t.Run("complete release with tests", func(t *testing.T) {
 		rel := &release.Release{


### PR DESCRIPTION
This PR adds defensive nil checks to HReleaseToJSON and HReleaseToHistElem to prevent potential nil pointer dereference panics when transforming release objects with missing info, chart, or metadata fields.